### PR TITLE
add sakura solarized information and ubuntu repository

### DIFF
--- a/projects/solarized/README.md
+++ b/projects/solarized/README.md
@@ -74,7 +74,13 @@ Currently available in formats for (cf [screenshots](#screenshots) below):
 * **iTerm2**
 * **OS X Terminal.app**
 * **Putty** courtesy [Brant Bobby](http://www.control-v.net)
-    and on [GitHub](https://github.com/brantb)
+  and on [GitHub](https://github.com/brantb)
+* **sakura** has support for a solarized palette in its
+  [latest development code](https://launchpad.net/sakura).
+  Builds for Ubuntu series precise and quantal are available in
+  [Chris Weyl's](http://whitepointstarllc.com)
+  [PPA](https://launchpad.net/~rsrchboy/+archive/ppa).
+
 
 ### Other Applications
 


### PR DESCRIPTION
The latest devel levels of sakura support the solarized palette.  However,
AFAIK this isn't avilable through any formal source, so to make my life easier
across multiple machines, I've built my own package.

As it's in a launchpad PPA, there's no reason other people can't use it as well,
at least until ubuntu catches up to the development trunk :)
