### PR TITLE
Fix code block formatting

### DIFF
--- a/projects/solarized/vim-colors-solarized/README.mkd
+++ b/projects/solarized/vim-colors-solarized/README.mkd
@@ -132,7 +132,7 @@ Solarized will work out of the box with just the two lines specified above but
 does include several other options that can be set in your .vimrc file.
 
 Set these in your vimrc file prior to calling the colorscheme.
-"
+
     option name               default     optional
     ------------------------------------------------
     g:solarized_termcolors=   16      |   256


### PR DESCRIPTION
Current page (http://ethanschoonover.com/solarized/vim-colors-solarized) has this problem:

<img width="975" alt="screen shot 2017-03-12 at 3 24 31 pm" src="https://cloud.githubusercontent.com/assets/5283282/23836591/0211ac5e-0738-11e7-986a-456b849013f4.png">

Now:

<img width="981" alt="screen shot 2017-03-12 at 3 26 06 pm" src="https://cloud.githubusercontent.com/assets/5283282/23836608/42e9865c-0738-11e7-8e61-81847f30d19c.png">


